### PR TITLE
feat: add clearable memoize cache groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,36 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 :wrench: A set of general-purpose decorators written in TypeScript following [tc39/proposal-decorators (Stage 3)](https://github.com/tc39/proposal-decorators).
+
+## Clearable memoize groups
+
+Use `createMemoizeCacheGroup` when a feature needs both a memoized function/decorator and an explicit invalidation hook.
+
+```ts
+import { createMemoizeCacheGroup } from 'at-decorators';
+
+const usersCache = createMemoizeCacheGroup({
+  cacheDuration: 24 * 60 * 60 * 1000,
+  maxCacheSizePerTarget: 10_000,
+});
+
+export const memoizeForUsers = usersCache.memoize;
+export const clearCachesForUsers = usersCache.clear;
+```
+
+Use `getGlobalMemoizeCacheStore` when several route bundles or module instances must clear the same cache groups.
+
+```ts
+import { createMemoizeCacheGroup, getGlobalMemoizeCacheStore } from 'at-decorators';
+
+const cacheStore = getGlobalMemoizeCacheStore(Symbol.for('myAppMemoizeCacheStore'), ['headers', 'users'] as const);
+
+const headersCache = createMemoizeCacheGroup({
+  cacheDuration: 10 * 60 * 1000,
+  caches: cacheStore.headers,
+  maxCacheSizePerTarget: 1000,
+});
+
+export const memoizeForHeaders = headersCache.memoize;
+export const clearCachesForHeaders = headersCache.clear;
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,14 @@
 export { getCacheKeyOfHash, getCacheKeyOfEmptyString, getCacheKeyOfStringified } from './getCacheKey.js';
 export { sha3_512 } from './hash.js';
 export { memoize, memoizeFactory } from './memoize.js';
+export {
+  clearMemoizeCaches,
+  createMemoizeCacheGroup,
+  getGlobalMemoizeCacheStore,
+  type MemoizeCache,
+  type MemoizeCacheGroup,
+  type MemoizeCacheGroupOptions,
+} from './memoizeCacheGroup.js';
 export { memoizeOne, memoizeOneWithEmptyHash, memoizeOneFactory } from './memoizeOne.js';
 export { memoizeWithPersistentCacheFactory } from './memoizeWithPersistentCache.js';
 export { stringify } from './oson/stringify.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 export { getCacheKeyOfHash, getCacheKeyOfEmptyString, getCacheKeyOfStringified } from './getCacheKey.js';
 export { sha3_512 } from './hash.js';
-export { memoize, memoizeFactory } from './memoize.js';
+export { memoize, memoizeFactory, type MemoizeCache, type MemoizeCacheRegistry } from './memoize.js';
 export {
   clearMemoizeCaches,
   createMemoizeCacheGroup,
   getGlobalMemoizeCacheStore,
-  type MemoizeCache,
   type MemoizeCacheGroup,
   type MemoizeCacheGroupOptions,
 } from './memoizeCacheGroup.js';

--- a/src/memoize.ts
+++ b/src/memoize.ts
@@ -1,5 +1,12 @@
 import { getCacheKeyOfHash } from './getCacheKey.js';
 
+export type MemoizeCache = Map<string, [unknown, number]>;
+
+export interface MemoizeCacheRegistry extends Iterable<MemoizeCache> {
+  readonly length: number;
+  push(...caches: MemoizeCache[]): number;
+}
+
 /**
  * A memoization decorator/function that caches the results of method/getter/function calls to improve performance.
  * This decorator/function can be applied to methods and getters in a class as a decorator, and functions without context as a function.
@@ -27,7 +34,7 @@ export const memoize = memoizeFactory();
  * @param {number} [options.maxCacheSizePerTarget=10000] - The maximum number of distinct values that can be cached.
  * @param {number} [options.cacheDuration=Number.POSITIVE_INFINITY] - The maximum number of milliseconds that a cached value is valid.
  * @param {Function} [options.getCacheKey] - A function to calculate the cache key for a given context and arguments. Defaults to hashing the stringified context and arguments.
- * @param {Map<string, [unknown, number]>[]} [options.caches] - An array of maps to store cached values. Useful for tracking and clearing caches externally.
+ * @param {MemoizeCacheRegistry} [options.caches] - A registry to store cached values. Useful for tracking and clearing caches externally.
  * @returns {Function} A new memoize function with the specified cache settings.
  */
 export function memoizeFactory({
@@ -37,7 +44,7 @@ export function memoizeFactory({
   maxCacheSizePerTarget = 10_000,
 }: {
   cacheDuration?: number;
-  caches?: Map<string, [unknown, number]>[];
+  caches?: MemoizeCacheRegistry;
   getCacheKey?: (self: unknown, args: unknown[]) => string;
   maxCacheSizePerTarget?: number;
 } = {}) {

--- a/src/memoizeCacheGroup.ts
+++ b/src/memoizeCacheGroup.ts
@@ -1,15 +1,15 @@
-import { memoizeFactory } from './memoize.js';
+import { memoizeFactory, type MemoizeCache, type MemoizeCacheRegistry } from './memoize.js';
 
-export type MemoizeCache = Map<string, [unknown, number]>;
+const MEMOIZE_CACHE_STORE_MARK = Symbol.for('at-decorators.memoizeCacheStore');
 
 export interface MemoizeCacheGroup {
-  readonly caches: MemoizeCache[];
+  readonly caches: MemoizeCacheRegistry;
   readonly clear: () => void;
   readonly memoize: ReturnType<typeof memoizeFactory>;
 }
 
 export type MemoizeCacheGroupOptions = Omit<NonNullable<Parameters<typeof memoizeFactory>[0]>, 'caches'> & {
-  caches?: MemoizeCache[];
+  caches?: MemoizeCacheRegistry;
 };
 
 export function createMemoizeCacheGroup(options: MemoizeCacheGroupOptions = {}): MemoizeCacheGroup {
@@ -24,7 +24,7 @@ export function createMemoizeCacheGroup(options: MemoizeCacheGroupOptions = {}):
   };
 }
 
-export function clearMemoizeCaches(caches: readonly MemoizeCache[]): void {
+export function clearMemoizeCaches(caches: Iterable<MemoizeCache>): void {
   for (const cache of caches) {
     cache.clear();
   }
@@ -33,71 +33,81 @@ export function clearMemoizeCaches(caches: readonly MemoizeCache[]): void {
 export function getGlobalMemoizeCacheStore<const Name extends string>(
   globalKey: string | symbol,
   names: readonly Name[]
-): Record<Name, MemoizeCache[]> {
+): Record<Name, MemoizeCacheRegistry> {
   const store = getOrCreateGlobalStore(globalKey);
 
   for (const name of names) {
     const cacheGroup = store[name];
-    if (!Array.isArray(cacheGroup)) {
+    if (!isMemoizeCacheRegistry(cacheGroup)) {
       store[name] = createWeakMemoizeCacheList();
     }
   }
 
-  return store as Record<Name, MemoizeCache[]>;
+  return store as Record<Name, MemoizeCacheRegistry>;
 }
 
-function createWeakMemoizeCacheList(): MemoizeCache[] {
+function createWeakMemoizeCacheList(): MemoizeCacheRegistry {
   const cacheRefs: WeakRef<MemoizeCache>[] = [];
 
-  return new Proxy([], {
-    get(target, property, receiver) {
-      if (property === 'length') {
-        pruneCollectedCaches(cacheRefs);
-        return cacheRefs.length;
-      }
-
-      if (property === 'push') {
-        return (...caches: MemoizeCache[]) => {
-          pruneCollectedCaches(cacheRefs);
-          for (const cache of caches) {
-            cacheRefs.push(new WeakRef(cache));
-          }
-          return cacheRefs.length;
-        };
-      }
-
-      if (property === Symbol.iterator) {
-        return function* () {
-          for (const cache of getAliveCaches(cacheRefs)) {
-            yield cache;
-          }
-        };
-      }
-
-      return Reflect.get(target, property, receiver);
+  return {
+    get length() {
+      pruneCollectedCaches(cacheRefs);
+      return cacheRefs.length;
     },
-  });
+    push: (...caches: MemoizeCache[]) => {
+      pruneCollectedCaches(cacheRefs);
+      for (const cache of caches) {
+        cacheRefs.push(new WeakRef(cache));
+      }
+      return cacheRefs.length;
+    },
+    *[Symbol.iterator]() {
+      for (const cache of getAliveCaches(cacheRefs)) {
+        yield cache;
+      }
+    },
+  };
 }
 
-function getOrCreateGlobalStore(globalKey: string | symbol): Record<string, MemoizeCache[]> {
+function getOrCreateGlobalStore(globalKey: string | symbol): Record<string, MemoizeCacheRegistry> {
   const globalWithCacheStore = globalThis as typeof globalThis & Record<PropertyKey, unknown>;
   const store = globalWithCacheStore[globalKey];
   if (isMemoizeCacheStore(store)) {
     return store;
   }
 
-  const newStore: Record<string, MemoizeCache[]> = {};
+  if (store !== undefined) {
+    throw new Error(`Global memoize cache store key is already occupied: ${String(globalKey)}`);
+  }
+
+  const newStore: Record<string, MemoizeCacheRegistry> = {};
+  Object.defineProperty(newStore, MEMOIZE_CACHE_STORE_MARK, {
+    value: true,
+  });
   globalWithCacheStore[globalKey] = newStore;
 
   return newStore;
 }
 
-function isMemoizeCacheStore(store: unknown): store is Record<string, MemoizeCache[]> {
+function isMemoizeCacheStore(store: unknown): store is Record<string, MemoizeCacheRegistry> {
   if (typeof store !== 'object' || store === null || Array.isArray(store)) {
     return false;
   }
 
-  return Object.values(store).every(Array.isArray);
+  return (store as Record<PropertyKey, unknown>)[MEMOIZE_CACHE_STORE_MARK] === true;
+}
+
+function isMemoizeCacheRegistry(value: unknown): value is MemoizeCacheRegistry {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const registry = value as Partial<MemoizeCacheRegistry>;
+  return (
+    typeof registry.length === 'number' &&
+    typeof registry.push === 'function' &&
+    typeof registry[Symbol.iterator] === 'function'
+  );
 }
 
 function getAliveCaches(cacheRefs: WeakRef<MemoizeCache>[]): MemoizeCache[] {

--- a/src/memoizeCacheGroup.ts
+++ b/src/memoizeCacheGroup.ts
@@ -39,11 +39,44 @@ export function getGlobalMemoizeCacheStore<const Name extends string>(
   for (const name of names) {
     const cacheGroup = store[name];
     if (!Array.isArray(cacheGroup)) {
-      store[name] = [];
+      store[name] = createWeakMemoizeCacheList();
     }
   }
 
   return store as Record<Name, MemoizeCache[]>;
+}
+
+function createWeakMemoizeCacheList(): MemoizeCache[] {
+  const cacheRefs: WeakRef<MemoizeCache>[] = [];
+
+  return new Proxy([], {
+    get(target, property, receiver) {
+      if (property === 'length') {
+        pruneCollectedCaches(cacheRefs);
+        return cacheRefs.length;
+      }
+
+      if (property === 'push') {
+        return (...caches: MemoizeCache[]) => {
+          pruneCollectedCaches(cacheRefs);
+          for (const cache of caches) {
+            cacheRefs.push(new WeakRef(cache));
+          }
+          return cacheRefs.length;
+        };
+      }
+
+      if (property === Symbol.iterator) {
+        return function* () {
+          for (const cache of getAliveCaches(cacheRefs)) {
+            yield cache;
+          }
+        };
+      }
+
+      return Reflect.get(target, property, receiver);
+    },
+  });
 }
 
 function getOrCreateGlobalStore(globalKey: string | symbol): Record<string, MemoizeCache[]> {
@@ -65,4 +98,27 @@ function isMemoizeCacheStore(store: unknown): store is Record<string, MemoizeCac
   }
 
   return Object.values(store).every(Array.isArray);
+}
+
+function getAliveCaches(cacheRefs: WeakRef<MemoizeCache>[]): MemoizeCache[] {
+  const caches: MemoizeCache[] = [];
+
+  for (let i = cacheRefs.length - 1; i >= 0; i--) {
+    const cache = cacheRefs[i]?.deref();
+    if (cache) {
+      caches.push(cache);
+    } else {
+      cacheRefs.splice(i, 1);
+    }
+  }
+
+  return caches.toReversed();
+}
+
+function pruneCollectedCaches(cacheRefs: WeakRef<MemoizeCache>[]): void {
+  for (let i = cacheRefs.length - 1; i >= 0; i--) {
+    if (!cacheRefs[i]?.deref()) {
+      cacheRefs.splice(i, 1);
+    }
+  }
 }

--- a/src/memoizeCacheGroup.ts
+++ b/src/memoizeCacheGroup.ts
@@ -1,0 +1,64 @@
+import { memoizeFactory } from './memoize.js';
+
+export type MemoizeCache = Map<string, [unknown, number]>;
+
+export interface MemoizeCacheGroup {
+  readonly caches: MemoizeCache[];
+  readonly clear: () => void;
+  readonly memoize: ReturnType<typeof memoizeFactory>;
+}
+
+export type MemoizeCacheGroupOptions = Omit<NonNullable<Parameters<typeof memoizeFactory>[0]>, 'caches'> & {
+  caches?: MemoizeCache[];
+};
+
+export function createMemoizeCacheGroup(options: MemoizeCacheGroupOptions = {}): MemoizeCacheGroup {
+  const { caches = [], ...memoizeOptions } = options;
+
+  return {
+    caches,
+    clear: () => {
+      clearMemoizeCaches(caches);
+    },
+    memoize: memoizeFactory({ ...memoizeOptions, caches }),
+  };
+}
+
+export function clearMemoizeCaches(caches: readonly MemoizeCache[]): void {
+  for (const cache of caches) {
+    cache.clear();
+  }
+}
+
+export function getGlobalMemoizeCacheStore<const Name extends string>(
+  globalKey: string | symbol,
+  names: readonly Name[]
+): Record<Name, MemoizeCache[]> {
+  const store = getOrCreateGlobalStore(globalKey);
+
+  for (const name of names) {
+    const cacheGroup = store[name];
+    if (!Array.isArray(cacheGroup)) {
+      store[name] = [];
+    }
+  }
+
+  return store as Record<Name, MemoizeCache[]>;
+}
+
+function getOrCreateGlobalStore(globalKey: string | symbol): Record<string, MemoizeCache[]> {
+  const globalWithCacheStore = globalThis as typeof globalThis & Record<PropertyKey, unknown>;
+  const store = globalWithCacheStore[globalKey];
+  if (isMemoizeCacheStore(store)) {
+    return store;
+  }
+
+  const newStore: Record<string, MemoizeCache[]> = {};
+  globalWithCacheStore[globalKey] = newStore;
+
+  return newStore;
+}
+
+function isMemoizeCacheStore(store: unknown): store is Record<string, MemoizeCache[]> {
+  return typeof store === 'object' && store !== null && !Array.isArray(store);
+}

--- a/src/memoizeCacheGroup.ts
+++ b/src/memoizeCacheGroup.ts
@@ -1,6 +1,7 @@
 import { memoizeFactory, type MemoizeCache, type MemoizeCacheRegistry } from './memoize.js';
 
 const MEMOIZE_CACHE_STORE_MARK = Symbol.for('at-decorators.memoizeCacheStore');
+const MIN_CACHE_REF_PRUNE_SIZE = 1024;
 
 export interface MemoizeCacheGroup {
   readonly caches: MemoizeCacheRegistry;
@@ -8,9 +9,7 @@ export interface MemoizeCacheGroup {
   readonly memoize: ReturnType<typeof memoizeFactory>;
 }
 
-export type MemoizeCacheGroupOptions = Omit<NonNullable<Parameters<typeof memoizeFactory>[0]>, 'caches'> & {
-  caches?: MemoizeCacheRegistry;
-};
+export type MemoizeCacheGroupOptions = NonNullable<Parameters<typeof memoizeFactory>[0]>;
 
 export function createMemoizeCacheGroup(options: MemoizeCacheGroupOptions = {}): MemoizeCacheGroup {
   const { caches = createWeakMemoizeCacheList(), ...memoizeOptions } = options;
@@ -48,15 +47,21 @@ export function getGlobalMemoizeCacheStore<const Name extends string>(
 
 function createWeakMemoizeCacheList(): MemoizeCacheRegistry {
   const cacheRefs: WeakRef<MemoizeCache>[] = [];
+  let nextPruneSize = MIN_CACHE_REF_PRUNE_SIZE;
 
   return {
     get length() {
       pruneCollectedCaches(cacheRefs);
+      nextPruneSize = getNextPruneSize(cacheRefs.length);
       return cacheRefs.length;
     },
     push: (...caches: MemoizeCache[]) => {
       for (const cache of caches) {
         cacheRefs.push(new WeakRef(cache));
+      }
+      if (cacheRefs.length >= nextPruneSize) {
+        pruneCollectedCaches(cacheRefs);
+        nextPruneSize = getNextPruneSize(cacheRefs.length);
       }
       return cacheRefs.length;
     },
@@ -143,4 +148,8 @@ function pruneCollectedCaches(cacheRefs: WeakRef<MemoizeCache>[]): void {
       cacheRefs.splice(i, 1);
     }
   }
+}
+
+function getNextPruneSize(cacheRefCount: number): number {
+  return Math.max(cacheRefCount * 2, MIN_CACHE_REF_PRUNE_SIZE);
 }

--- a/src/memoizeCacheGroup.ts
+++ b/src/memoizeCacheGroup.ts
@@ -39,7 +39,7 @@ export function getGlobalMemoizeCacheStore<const Name extends string>(
   for (const name of names) {
     const cacheGroup = store[name];
     if (!isMemoizeCacheRegistry(cacheGroup)) {
-      store[name] = createWeakMemoizeCacheList();
+      defineMemoizeCacheRegistry(store, name, createWeakMemoizeCacheList());
     }
   }
 
@@ -55,7 +55,6 @@ function createWeakMemoizeCacheList(): MemoizeCacheRegistry {
       return cacheRefs.length;
     },
     push: (...caches: MemoizeCache[]) => {
-      pruneCollectedCaches(cacheRefs);
       for (const cache of caches) {
         cacheRefs.push(new WeakRef(cache));
       }
@@ -80,13 +79,26 @@ function getOrCreateGlobalStore(globalKey: string | symbol): Record<string, Memo
     throw new Error(`Global memoize cache store key is already occupied: ${String(globalKey)}`);
   }
 
-  const newStore: Record<string, MemoizeCacheRegistry> = {};
+  const newStore = Object.create(null) as Record<string, MemoizeCacheRegistry>;
   Object.defineProperty(newStore, MEMOIZE_CACHE_STORE_MARK, {
     value: true,
   });
   globalWithCacheStore[globalKey] = newStore;
 
   return newStore;
+}
+
+function defineMemoizeCacheRegistry(
+  store: Record<string, MemoizeCacheRegistry>,
+  name: string,
+  registry: MemoizeCacheRegistry
+): void {
+  Object.defineProperty(store, name, {
+    configurable: true,
+    enumerable: true,
+    value: registry,
+    writable: true,
+  });
 }
 
 function isMemoizeCacheStore(store: unknown): store is Record<string, MemoizeCacheRegistry> {

--- a/src/memoizeCacheGroup.ts
+++ b/src/memoizeCacheGroup.ts
@@ -13,7 +13,7 @@ export type MemoizeCacheGroupOptions = Omit<NonNullable<Parameters<typeof memoiz
 };
 
 export function createMemoizeCacheGroup(options: MemoizeCacheGroupOptions = {}): MemoizeCacheGroup {
-  const { caches = [], ...memoizeOptions } = options;
+  const { caches = createWeakMemoizeCacheList(), ...memoizeOptions } = options;
 
   return {
     caches,

--- a/src/memoizeCacheGroup.ts
+++ b/src/memoizeCacheGroup.ts
@@ -60,5 +60,9 @@ function getOrCreateGlobalStore(globalKey: string | symbol): Record<string, Memo
 }
 
 function isMemoizeCacheStore(store: unknown): store is Record<string, MemoizeCache[]> {
-  return typeof store === 'object' && store !== null && !Array.isArray(store);
+  if (typeof store !== 'object' || store === null || Array.isArray(store)) {
+    return false;
+  }
+
+  return Object.values(store).every(Array.isArray);
 }

--- a/src/memoizeWithPersistentCache.ts
+++ b/src/memoizeWithPersistentCache.ts
@@ -1,4 +1,5 @@
 import { getCacheKeyOfHash } from './getCacheKey.js';
+import type { MemoizeCacheRegistry } from './memoize.js';
 
 /**
  * Factory function to create a memoize function with custom cache sizes.
@@ -10,7 +11,7 @@ import { getCacheKeyOfHash } from './getCacheKey.js';
  * @param {number} [options.maxCacheSizePerTarget=10000] - The maximum number of distinct values that can be cached.
  * @param {number} [options.cacheDuration=Number.POSITIVE_INFINITY] - The maximum number of milliseconds that a cached value is valid.
  * @param {Function} [options.getCacheKey] - A function to calculate the cache key for a given context and arguments. Defaults to hashing the stringified context and arguments.
- * @param {Map<string, [unknown, number]>[]} [options.caches] - An array of maps to store cached values.
+ * @param {MemoizeCacheRegistry} [options.caches] - A registry to store cached values.
  * @param {Function} options.persistCache - A function to store cached values with current time persistently.
  * @param {Function} options.tryReadingCache - A function to try reading cached values from persistent storage.
  * @param {Function} options.removeCache - A function to remove cached values.
@@ -26,7 +27,7 @@ export function memoizeWithPersistentCacheFactory({
   tryReadingCache,
 }: {
   cacheDuration?: number;
-  caches?: Map<string, [unknown, number]>[];
+  caches?: MemoizeCacheRegistry;
   getCacheKey?: (self: unknown, args: unknown[]) => string;
   maxCacheSizePerTarget?: number;
   persistCache: (persistentKey: string, hash: string, value: unknown, currentTime: number) => unknown;


### PR DESCRIPTION
## Summary
- add `createMemoizeCacheGroup` for pairing memoized functions/decorators with a clear operation
- add `getGlobalMemoizeCacheStore` so Next route bundles or duplicate module instances can share clear targets
- document the intended replacement pattern for app-local memoize wrapper code

## Verification
- `yarn check-for-ai`
- `yarn typecheck`