### PR TITLE
fix: improve memoize typings and cache performance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
 export { getCacheKeyOfHash, getCacheKeyOfEmptyString, getCacheKeyOfStringified } from './getCacheKey.js';
 export { sha3_512 } from './hash.js';
-export { memoize, memoizeFactory, type MemoizeCache, type MemoizeCacheRegistry } from './memoize.js';
+export {
+  memoize,
+  memoizeFactory,
+  type GetCacheKey,
+  type Memoize,
+  type MemoizeCache,
+  type MemoizeCacheRegistry,
+} from './memoize.js';
 export {
   clearMemoizeCaches,
   createMemoizeCacheGroup,
@@ -9,5 +16,9 @@ export {
   type MemoizeCacheGroupOptions,
 } from './memoizeCacheGroup.js';
 export { memoizeOne, memoizeOneWithEmptyHash, memoizeOneFactory } from './memoizeOne.js';
-export { memoizeWithPersistentCacheFactory } from './memoizeWithPersistentCache.js';
+export {
+  memoizeWithPersistentCacheFactory,
+  type MemoizeWithPersistentCache,
+  type MemoizeWithPersistentCacheOptions,
+} from './memoizeWithPersistentCache.js';
 export { stringify } from './oson/stringify.js';

--- a/src/memoize.ts
+++ b/src/memoize.ts
@@ -1,6 +1,19 @@
 import { getCacheKeyOfHash } from './getCacheKey.js';
 
 export type MemoizeCache = Map<string, [unknown, number]>;
+export type GetCacheKey<This = unknown, Args extends unknown[] = unknown[]> = (self: This, args: Args) => string;
+
+export interface Memoize {
+  <This, Args extends unknown[], Return>(
+    target: (this: This, ...args: Args) => Return,
+    context: ClassMethodDecoratorContext<This, (this: This, ...args: Args) => Return>
+  ): (this: This, ...args: Args) => Return;
+  <This, Return>(
+    target: (this: This) => Return,
+    context: ClassGetterDecoratorContext<This, Return>
+  ): (this: This) => Return;
+  <Args extends unknown[], Return>(target: (...args: Args) => Return): (...args: Args) => Return;
+}
 
 export interface MemoizeCacheRegistry extends Iterable<MemoizeCache> {
   readonly length: number;
@@ -45,11 +58,11 @@ export function memoizeFactory({
 }: {
   cacheDuration?: number;
   caches?: MemoizeCacheRegistry;
-  getCacheKey?: (self: unknown, args: unknown[]) => string;
+  getCacheKey?: GetCacheKey;
   maxCacheSizePerTarget?: number;
-} = {}) {
+} = {}): Memoize {
   return function memoize<This, Args extends unknown[], Return>(
-    target: ((this: This, ...args: Args) => Return) | ((...args: Args) => Return) | keyof This,
+    target: ((this: This, ...args: Args) => Return) | ((...args: Args) => Return),
     context?:
       | ClassMethodDecoratorContext<This, (this: This, ...args: Args) => Return>
       | ClassGetterDecoratorContext<This, Return>
@@ -61,9 +74,10 @@ export function memoizeFactory({
       ? function (this: This) {
           const hash = getCacheKey(this, []);
           const now = Date.now();
+          const cacheEntry = cache.get(hash);
 
-          if (cache.has(hash)) {
-            const [cachedValue, cachedAt] = cache.get(hash) as [Return, number];
+          if (cacheEntry) {
+            const [cachedValue, cachedAt] = cacheEntry;
             if (now - cachedAt <= cacheDuration) {
               return cachedValue;
             }
@@ -82,9 +96,10 @@ export function memoizeFactory({
       : function (this: This, ...args: Args) {
           const hash = getCacheKey(this, args);
           const now = Date.now();
+          const cacheEntry = cache.get(hash);
 
-          if (cache.has(hash)) {
-            const [cachedValue, cachedAt] = cache.get(hash) as [Return, number];
+          if (cacheEntry) {
+            const [cachedValue, cachedAt] = cacheEntry;
             if (now - cachedAt <= cacheDuration) {
               return cachedValue;
             }
@@ -103,5 +118,5 @@ export function memoizeFactory({
 
           return result;
         };
-  };
+  } as Memoize;
 }

--- a/src/memoizeCacheGroup.ts
+++ b/src/memoizeCacheGroup.ts
@@ -66,7 +66,7 @@ function createWeakMemoizeCacheList(): MemoizeCacheRegistry {
       return cacheRefs.length;
     },
     *[Symbol.iterator]() {
-      for (const cache of getAliveCaches(cacheRefs)) {
+      for (const cache of pruneAndGetAliveCaches(cacheRefs)) {
         yield cache;
       }
     },
@@ -127,27 +127,33 @@ function isMemoizeCacheRegistry(value: unknown): value is MemoizeCacheRegistry {
   );
 }
 
-function getAliveCaches(cacheRefs: WeakRef<MemoizeCache>[]): MemoizeCache[] {
+function pruneAndGetAliveCaches(cacheRefs: WeakRef<MemoizeCache>[]): MemoizeCache[] {
   const caches: MemoizeCache[] = [];
+  let nextCacheRefIndex = 0;
 
-  for (let i = cacheRefs.length - 1; i >= 0; i--) {
-    const cache = cacheRefs[i]?.deref();
+  for (const cacheRef of cacheRefs) {
+    const cache = cacheRef.deref();
     if (cache) {
       caches.push(cache);
-    } else {
-      cacheRefs.splice(i, 1);
+      cacheRefs[nextCacheRefIndex] = cacheRef;
+      nextCacheRefIndex++;
     }
   }
+  cacheRefs.length = nextCacheRefIndex;
 
-  return caches.toReversed();
+  return caches;
 }
 
 function pruneCollectedCaches(cacheRefs: WeakRef<MemoizeCache>[]): void {
-  for (let i = cacheRefs.length - 1; i >= 0; i--) {
-    if (!cacheRefs[i]?.deref()) {
-      cacheRefs.splice(i, 1);
+  let nextCacheRefIndex = 0;
+
+  for (const cacheRef of cacheRefs) {
+    if (cacheRef.deref()) {
+      cacheRefs[nextCacheRefIndex] = cacheRef;
+      nextCacheRefIndex++;
     }
   }
+  cacheRefs.length = nextCacheRefIndex;
 }
 
 function getNextPruneSize(cacheRefCount: number): number {

--- a/src/memoizeOne.ts
+++ b/src/memoizeOne.ts
@@ -1,4 +1,5 @@
 import { getCacheKeyOfEmptyString, getCacheKeyOfHash } from './getCacheKey.js';
+import type { GetCacheKey, Memoize } from './memoize.js';
 
 /**
  * A memoization decorator/function that caches the results of the latest method/getter/function call to improve performance.
@@ -49,9 +50,9 @@ export const memoizeOneWithEmptyHash = memoizeOneFactory({ getCacheKey: getCache
 export function memoizeOneFactory({
   cacheDuration = Number.POSITIVE_INFINITY,
   getCacheKey = getCacheKeyOfHash,
-}: { cacheDuration?: number; getCacheKey?: (self: unknown, args: unknown[]) => string } = {}) {
+}: { cacheDuration?: number; getCacheKey?: GetCacheKey } = {}): Memoize {
   return function <This, Args extends unknown[], Return>(
-    target: ((this: This, ...args: Args) => Return) | ((...args: Args) => Return) | keyof This,
+    target: ((this: This, ...args: Args) => Return) | ((...args: Args) => Return),
     context?:
       | ClassMethodDecoratorContext<This, (this: This, ...args: Args) => Return>
       | ClassGetterDecoratorContext<This, Return>
@@ -83,5 +84,5 @@ export function memoizeOneFactory({
           }
           return lastCache;
         };
-  };
+  } as Memoize;
 }

--- a/src/memoizeWithPersistentCache.ts
+++ b/src/memoizeWithPersistentCache.ts
@@ -1,5 +1,29 @@
 import { getCacheKeyOfHash } from './getCacheKey.js';
-import type { MemoizeCacheRegistry } from './memoize.js';
+import type { GetCacheKey, MemoizeCacheRegistry } from './memoize.js';
+
+type MaybePromise<T> = T | PromiseLike<T>;
+
+export interface MemoizeWithPersistentCacheOptions {
+  cacheDuration?: number;
+  caches?: MemoizeCacheRegistry;
+  getCacheKey?: GetCacheKey;
+  maxCacheSizePerTarget?: number;
+  persistCache: (persistentKey: string, hash: string, value: unknown, currentTime: number) => MaybePromise<unknown>;
+  removeCache: (persistentKey: string, hash: string) => MaybePromise<unknown>;
+  tryReadingCache: (persistentKey: string, hash: string) => [unknown, number] | undefined;
+}
+
+export interface MemoizeWithPersistentCache {
+  <This, Args extends unknown[], Return>(
+    target: (this: This, ...args: Args) => Return,
+    context: ClassMethodDecoratorContext<This, (this: This, ...args: Args) => Return>
+  ): (this: This, ...args: Args) => Return;
+  <This, Return>(
+    target: (this: This) => Return,
+    context: ClassGetterDecoratorContext<This, Return>
+  ): (this: This) => Return;
+  <Args extends unknown[], Return>(target: (...args: Args) => Return): (...args: Args) => Return;
+}
 
 /**
  * Factory function to create a memoize function with custom cache sizes.
@@ -25,45 +49,32 @@ export function memoizeWithPersistentCacheFactory({
   persistCache,
   removeCache,
   tryReadingCache,
-}: {
-  cacheDuration?: number;
-  caches?: MemoizeCacheRegistry;
-  getCacheKey?: (self: unknown, args: unknown[]) => string;
-  maxCacheSizePerTarget?: number;
-  persistCache: (persistentKey: string, hash: string, value: unknown, currentTime: number) => unknown;
-  removeCache: (persistentKey: string, hash: string) => unknown;
-  tryReadingCache: (persistentKey: string, hash: string) => [unknown, number] | undefined;
-}) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function <This, Args extends any[], Return>(persistentKey: string) {
+}: MemoizeWithPersistentCacheOptions): (persistentKey: string) => MemoizeWithPersistentCache {
+  return function (persistentKey: string) {
     return function memoize(
-      target: ((this: This, ...args: Args) => Return) | ((...args: Args) => Return) | keyof This,
+      target: ((this: unknown, ...args: unknown[]) => unknown) | ((...args: unknown[]) => unknown),
       context?:
-        | ClassMethodDecoratorContext<This, (this: This, ...args: Args) => Return>
-        | ClassGetterDecoratorContext<This, Return>
+        | ClassMethodDecoratorContext<unknown, (this: unknown, ...args: unknown[]) => unknown>
+        | ClassGetterDecoratorContext<unknown, unknown>
     ) {
-      const cache = new Map<string, [Return, number]>();
+      const cache = new Map<string, [unknown, number]>();
       caches?.push(cache);
 
       return context?.kind === 'getter'
-        ? function (this: This) {
+        ? function (this: unknown) {
             const hash = getCacheKey(this, []);
             const now = Date.now();
+            const cacheEntry = cache.get(hash);
 
             // Check in-memory cache first
-            if (cache.has(hash)) {
-              const [cachedValue, cachedAt] = cache.get(hash) as [Return, number];
+            if (cacheEntry) {
+              const [cachedValue, cachedAt] = cacheEntry;
               if (now - cachedAt <= cacheDuration) {
                 return cachedValue;
               }
 
               cache.delete(hash);
-              try {
-                const promise = removeCache(persistentKey, hash);
-                if (promise instanceof Promise) promise.catch(noop);
-              } catch {
-                // do nothing.
-              }
+              ignoreCacheOperationError(() => removeCache(persistentKey, hash));
             }
 
             // Try reading from persistent cache
@@ -72,67 +83,47 @@ export function memoizeWithPersistentCacheFactory({
               if (persistentCache) {
                 const [cachedValue, cachedAt] = persistentCache;
                 if (now - cachedAt <= cacheDuration) {
-                  cache.set(hash, [cachedValue as Return, cachedAt]);
-                  return cachedValue as Return;
+                  cache.set(hash, [cachedValue, cachedAt]);
+                  return cachedValue;
                 }
 
-                const promise = removeCache(persistentKey, hash);
-                if (promise instanceof Promise) promise.catch(noop);
+                ignoreCacheOperationError(() => removeCache(persistentKey, hash));
               }
             } catch {
               // do nothing.
             }
 
-            const result = (target as (this: This) => Return).call(this);
+            const result = (target as (this: unknown) => unknown).call(this);
             if (cache.size >= maxCacheSizePerTarget) {
               const oldestKey = cache.keys().next().value as string;
               cache.delete(oldestKey);
-              try {
-                const promise = removeCache(persistentKey, oldestKey);
-                if (promise instanceof Promise) promise.catch(noop);
-              } catch {
-                // do nothing.
-              }
+              ignoreCacheOperationError(() => removeCache(persistentKey, oldestKey));
             }
             cache.set(hash, [result, now]);
-            if (result instanceof Promise) {
+            if (isPromiseLike(result)) {
               void (async () => {
-                try {
-                  const promise = persistCache(persistentKey, hash, await result, now);
-                  if (promise instanceof Promise) promise.catch(noop);
-                } catch {
-                  // do nothing.
-                }
+                ignoreCacheOperationError(async () => persistCache(persistentKey, hash, await result, now));
               })();
             } else {
-              try {
-                const promise = persistCache(persistentKey, hash, result, now);
-                if (promise instanceof Promise) promise.catch(noop);
-              } catch {
-                // do nothing.
-              }
+              ignoreCacheOperationError(() => persistCache(persistentKey, hash, result, now));
             }
 
             return result;
           }
-        : function (this: This, ...args: { [K in keyof Args]: Args[K] }) {
+        : function (this: unknown, ...args: unknown[]) {
             const hash = getCacheKey(this, args);
             const now = Date.now();
+            const cacheEntry = cache.get(hash);
 
             // Check in-memory cache first
-            if (cache.has(hash)) {
-              const [cachedValue, cachedAt] = cache.get(hash) as [Return, number];
+            if (cacheEntry) {
+              const [cachedValue, cachedAt] = cacheEntry;
               if (now - cachedAt <= cacheDuration) {
                 return cachedValue;
               }
 
               cache.delete(hash);
-              try {
-                const promise = removeCache(persistentKey, hash);
-                if (promise instanceof Promise) promise.catch(noop);
-              } catch {
-                // do nothing.
-              }
+              ignoreCacheOperationError(() => removeCache(persistentKey, hash));
             }
 
             // Try reading from persistent cache
@@ -141,55 +132,56 @@ export function memoizeWithPersistentCacheFactory({
               if (persistentCache) {
                 const [cachedValue, cachedAt] = persistentCache;
                 if (now - cachedAt <= cacheDuration) {
-                  cache.set(hash, [cachedValue as Return, cachedAt]);
-                  return cachedValue as Return;
+                  cache.set(hash, [cachedValue, cachedAt]);
+                  return cachedValue;
                 }
 
-                const promise = removeCache(persistentKey, hash);
-                if (promise instanceof Promise) promise.catch(noop);
+                ignoreCacheOperationError(() => removeCache(persistentKey, hash));
               }
             } catch {
               // do nothing.
             }
 
             const result = context
-              ? (target as (this: This, ...args: Args) => Return).call(this, ...args)
-              : (target as (...args: Args) => Return)(...args);
+              ? (target as (this: unknown, ...args: unknown[]) => unknown).call(this, ...args)
+              : (target as (...args: unknown[]) => unknown)(...args);
 
             if (cache.size >= maxCacheSizePerTarget) {
               const oldestKey = cache.keys().next().value as string;
               cache.delete(oldestKey);
-              try {
-                const promise = removeCache(persistentKey, oldestKey);
-                if (promise instanceof Promise) promise.catch(noop);
-              } catch {
-                // do nothing.
-              }
+              ignoreCacheOperationError(() => removeCache(persistentKey, oldestKey));
             }
             cache.set(hash, [result, now]);
-            if (result instanceof Promise) {
+            if (isPromiseLike(result)) {
               void (async () => {
-                try {
-                  const promise = persistCache(persistentKey, hash, await result, now);
-                  if (promise instanceof Promise) promise.catch(noop);
-                } catch {
-                  // do nothing.
-                }
+                ignoreCacheOperationError(async () => persistCache(persistentKey, hash, await result, now));
               })();
             } else {
-              try {
-                const promise = persistCache(persistentKey, hash, result, now);
-                if (promise instanceof Promise) promise.catch(noop);
-              } catch {
-                // do nothing.
-              }
+              ignoreCacheOperationError(() => persistCache(persistentKey, hash, result, now));
             }
 
             return result;
           };
-    };
+    } as MemoizeWithPersistentCache;
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = (): void => {};
+function ignoreCacheOperationError(operation: () => MaybePromise<unknown>): void {
+  try {
+    const result = operation();
+    if (isPromiseLike(result)) {
+      void result.then(undefined, noop);
+    }
+  } catch {
+    // do nothing.
+  }
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === 'object' && value !== null && 'then' in value && typeof value.then === 'function') ||
+    (typeof value === 'function' && 'then' in value && typeof value.then === 'function')
+  );
+}
+
+function noop(): void {}


### PR DESCRIPTION
## Customer Summary

- Improves TypeScript inference for memoization decorators and wrapper functions.
- Keeps runtime behavior compatible while reducing overhead in common cache paths.
- No migration steps are required for existing consumers.

## Technical Summary

- Added explicit public overload types for method decorators, getter decorators, and plain function memoizers.
- Exported reusable `GetCacheKey`, `Memoize`, `MemoizeWithPersistentCache`, and `MemoizeWithPersistentCacheOptions` types.
- Replaced repeated `Map.has` plus `Map.get` cache checks with single `Map.get` lookups.
- Compacted weak memoize cache registries in one pass instead of repeatedly splicing.
- Consolidated persistent cache hook error handling and accepts promise-like hook results.

## Why

- The previous single generic implementation signature made the public decorator/function surface less precise than the runtime behavior.
- The cache hot paths had avoidable extra lookups and registry pruning could become unnecessarily costly as references accumulated.

## Testing

- `yarn typecheck`
- `yarn lint`
- `yarn test`
- `yarn verify`
- CI passed on commit `5c3cd70`
