### PR TITLE
docs: refine README with features, usage guide, and API summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,99 @@
 # at-decorators
 
 [![Test](https://github.com/WillBooster/at-decorators/actions/workflows/test.yml/badge.svg)](https://github.com/WillBooster/at-decorators/actions/workflows/test.yml)
+[![npm version](https://img.shields.io/npm/v/at-decorators.svg)](https://www.npmjs.com/package/at-decorators)
+[![license](https://img.shields.io/npm/l/at-decorators.svg)](https://github.com/WillBooster/at-decorators/blob/main/LICENSE)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-:wrench: A set of general-purpose decorators written in TypeScript following [tc39/proposal-decorators (Stage 3)](https://github.com/tc39/proposal-decorators).
+:wrench: Fast, dependency-free memoization for TypeScript, built on [TC39 Stage 3 decorators](https://github.com/tc39/proposal-decorators) — for class methods, getters, and plain functions.
 
-## Clearable memoize groups
+## Features
 
-Use `createMemoizeCacheGroup` when a feature needs both a memoized function/decorator and an explicit invalidation hook.
+- **One API for everything** — apply the same `memoize` to class methods, getters (as a decorator), and standalone functions (as a wrapper).
+- **Structure-aware cache keys** — arguments are serialized (including `Map`, `Set`, `Date`, `RegExp`, `URL`, `Error`, `Uint8Array`, `bigint`, and circular references) and hashed with SHA3-512, so structurally equal arguments hit the same cache entry.
+- **Expiration and size limits** — per-entry TTL via `cacheDuration` and a FIFO size cap via `maxCacheSizePerTarget`.
+- **Explicit invalidation** — group memoized targets into clearable cache groups; caches are tracked via `WeakRef`, so they never leak.
+- **Pluggable persistence** — back the in-memory cache with any storage (file, Redis, database) through three small callbacks.
+- **Zero runtime dependencies** — ships ESM and CJS with type definitions.
+
+## Installation
+
+```sh
+npm install at-decorators # or yarn add / pnpm add / bun add
+```
+
+## Quick Start
+
+```ts
+import { memoize } from 'at-decorators';
+
+class UserService {
+  @memoize
+  fetchUser(userId: string): Promise<User> {
+    return fetch(`/api/users/${userId}`).then((res) => res.json());
+  }
+
+  @memoize
+  get config(): Config {
+    return loadConfigFromDisk();
+  }
+}
+
+// Plain functions work too — no decorator syntax required.
+const fibonacci = memoize((n: number): number => (n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2)));
+```
+
+Repeated calls with structurally equal arguments return the cached result without invoking the original implementation.
+
+## Usage
+
+### Custom cache settings: `memoizeFactory`
+
+Create a `memoize` with your own TTL, size limit, or cache-key derivation:
+
+```ts
+import { memoizeFactory } from 'at-decorators';
+
+const memoizeShortly = memoizeFactory({
+  cacheDuration: 60 * 1000, // Entries expire after 1 minute (default: no expiration).
+  maxCacheSizePerTarget: 100, // Keep at most 100 entries per method/getter/function (default: 10,000). The oldest entry is evicted first.
+});
+
+class ExchangeRateService {
+  @memoizeShortly
+  getRate(from: string, to: string): Promise<number> {
+    return fetchRate(from, to);
+  }
+}
+```
+
+| Option                  | Default                                     | Description                                                                     |
+| ----------------------- | ------------------------------------------- | ------------------------------------------------------------------------------- |
+| `cacheDuration`         | `Number.POSITIVE_INFINITY`                  | Milliseconds a cached value stays valid.                                        |
+| `maxCacheSizePerTarget` | `10_000`                                    | Maximum entries per memoized target; the oldest entry is evicted when exceeded. |
+| `getCacheKey`           | [`getCacheKeyOfHash`](#cache-key-functions) | Derives a string cache key from `this` and the arguments.                       |
+| `caches`                | `undefined`                                 | A registry that receives every created cache, for external tracking/clearing.   |
+
+### Caching only the latest result: `memoizeOne`
+
+`memoizeOne` remembers a single entry — ideal when arguments rarely change between consecutive calls and you want O(1) memory:
+
+```ts
+import { memoizeOne, memoizeOneWithEmptyHash, memoizeOneFactory } from 'at-decorators';
+
+// Re-computes only when the arguments (or `this`) change.
+const formatReport = memoizeOne((rows: Row[]) => rows.map(renderRow).join('\n'));
+
+// Ignores arguments entirely — computes once, then always returns the first result.
+const loadSettings = memoizeOneWithEmptyHash(() => JSON.parse(fs.readFileSync('settings.json', 'utf8')));
+
+// With a TTL: at most one re-computation per 5 seconds for the same arguments.
+const memoizeOneBriefly = memoizeOneFactory({ cacheDuration: 5000 });
+```
+
+### Clearable cache groups: `createMemoizeCacheGroup`
+
+Use `createMemoizeCacheGroup` when a feature needs both a memoized function/decorator and an explicit invalidation hook:
 
 ```ts
 import { createMemoizeCacheGroup } from 'at-decorators';
@@ -21,7 +107,9 @@ export const memoizeForUsers = usersCache.memoize;
 export const clearCachesForUsers = usersCache.clear;
 ```
 
-Use `getGlobalMemoizeCacheStore` when several route bundles or module instances must clear the same cache groups.
+Every target memoized with `memoizeForUsers` registers its cache in the group, and `clearCachesForUsers()` empties them all at once. Caches are held via `WeakRef`, so a group never prevents garbage collection of memoized targets.
+
+Use `getGlobalMemoizeCacheStore` when several bundles or module instances (e.g. separately bundled route handlers) must share and clear the same cache groups:
 
 ```ts
 import { createMemoizeCacheGroup, getGlobalMemoizeCacheStore } from 'at-decorators';
@@ -37,3 +125,80 @@ const headersCache = createMemoizeCacheGroup({
 export const memoizeForHeaders = headersCache.memoize;
 export const clearCachesForHeaders = headersCache.clear;
 ```
+
+The store lives on `globalThis` under the given key, so every module instance resolves the same registries. You can also clear an arbitrary collection of caches directly with `clearMemoizeCaches(caches)`.
+
+### Persistent caches: `memoizeWithPersistentCacheFactory`
+
+Keep cached values across process restarts by supplying three storage callbacks. Storage failures are swallowed, so a broken backend degrades to in-memory memoization instead of breaking calls:
+
+```ts
+import { memoizeWithPersistentCacheFactory } from 'at-decorators';
+
+const createPersistentMemoize = memoizeWithPersistentCacheFactory({
+  cacheDuration: 60 * 60 * 1000,
+  persistCache: (persistentKey, hash, value, currentTime) => db.upsert(persistentKey, hash, value, currentTime),
+  tryReadingCache: (persistentKey, hash) => db.read(persistentKey, hash), // Returns [value, cachedAt] or undefined.
+  removeCache: (persistentKey, hash) => db.remove(persistentKey, hash),
+});
+
+class GeocodingService {
+  @createPersistentMemoize('geocode')
+  geocode(address: string): Promise<Coordinates> {
+    return callGeocodingApi(address);
+  }
+}
+```
+
+Each memoized target gets a `persistentKey` namespace. Lookups check the in-memory cache first, then the persistent storage; promise results are persisted after they resolve.
+
+### Cache key functions
+
+The cache key determines what counts as "the same call". Three implementations are provided, and any `(self, args) => string` works via the `getCacheKey` option:
+
+```ts
+import { getCacheKeyOfHash, getCacheKeyOfStringified, getCacheKeyOfEmptyString, memoizeFactory } from 'at-decorators';
+
+// Default: SHA3-512 hash of the serialized `this` and arguments — fixed-length keys.
+const memoizeByHash = memoizeFactory({ getCacheKey: getCacheKeyOfHash });
+
+// Serialized `this` and arguments as-is — faster for small arguments, keys grow with input size.
+const memoizeByString = memoizeFactory({ getCacheKey: getCacheKeyOfStringified });
+
+// Ignore `this` and arguments — every call shares one cache entry.
+const memoizeIgnoringArgs = memoizeFactory({ getCacheKey: getCacheKeyOfEmptyString });
+
+// Custom: key on a single argument property.
+const memoizeByUserId = memoizeFactory({ getCacheKey: (_self, args) => (args[0] as { id: string }).id });
+```
+
+Serialization is powered by an embedded fork of [oson](https://github.com/KnorpelSenf/oson), which — unlike `JSON.stringify` — handles `undefined`, `bigint`, `NaN`, `Infinity`, `Map`, `Set`, `Date`, `RegExp`, `URL`, `Error`, `Uint8Array`, sparse arrays, and circular references. The serializer (`stringify`) and hash (`sha3_512`) are exported for direct use.
+
+## API Summary
+
+| Export                                                                        | Kind      | Description                                                           |
+| ----------------------------------------------------------------------------- | --------- | --------------------------------------------------------------------- |
+| `memoize`                                                                     | decorator | Memoize with default settings (10,000 entries per target, no TTL).    |
+| `memoizeFactory(options)`                                                     | factory   | Build a `memoize` with custom TTL, size limit, key function, caches.  |
+| `memoizeOne` / `memoizeOneWithEmptyHash`                                      | decorator | Cache only the latest result (keyed by arguments / shared).           |
+| `memoizeOneFactory(options)`                                                  | factory   | Build a `memoizeOne` with custom TTL or key function.                 |
+| `createMemoizeCacheGroup(options)`                                            | factory   | A `memoize` plus a `clear()` hook over all its caches.                |
+| `getGlobalMemoizeCacheStore(key, names)`                                      | function  | Shared, `globalThis`-backed cache registries for cross-bundle groups. |
+| `clearMemoizeCaches(caches)`                                                  | function  | Clear every cache in an iterable of caches.                           |
+| `memoizeWithPersistentCacheFactory(options)`                                  | factory   | Memoization backed by user-provided persistent storage.               |
+| `getCacheKeyOfHash` / `getCacheKeyOfStringified` / `getCacheKeyOfEmptyString` | function  | Built-in cache-key derivations.                                       |
+| `stringify(value)`                                                            | function  | Structure-preserving serialization (oson format).                     |
+| `sha3_512(text)`                                                              | function  | SHA3-512 hex digest of a string.                                      |
+
+## Requirements
+
+- **Decorators**: TypeScript 5.0+ (standard decorators, i.e. without `experimentalDecorators`), or Babel with [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/babel-plugin-proposal-decorators) (`version: '2023-05'`).
+- **Runtime**: any modern JavaScript runtime; plain-function usage requires no decorator support at all.
+
+## Contributing
+
+Issues and pull requests are welcome. Run `yarn install`, make your changes, and verify with `yarn test` and `yarn verify`.
+
+## License
+
+Apache-2.0 © [WillBooster Inc.](https://willbooster.com/) — see [LICENSE](LICENSE) and [NOTICE](NOTICE). Includes code derived from [oson](https://github.com/KnorpelSenf/oson) (MIT) and [js-sha3](https://github.com/emn178/js-sha3) (MIT).

--- a/README.md
+++ b/README.md
@@ -137,9 +137,12 @@ import { memoizeWithPersistentCacheFactory } from 'at-decorators';
 
 const createPersistentMemoize = memoizeWithPersistentCacheFactory({
   cacheDuration: 60 * 60 * 1000,
+  // `persistCache` and `removeCache` may be async; their results are ignored.
   persistCache: (persistentKey, hash, value, currentTime) => db.upsert(persistentKey, hash, value, currentTime),
-  tryReadingCache: (persistentKey, hash) => db.read(persistentKey, hash), // Returns [value, cachedAt] or undefined.
   removeCache: (persistentKey, hash) => db.remove(persistentKey, hash),
+  // `tryReadingCache` MUST be synchronous and return [value, cachedAt] or undefined;
+  // a Promise cannot be awaited here and would silently bypass the persistent lookup.
+  tryReadingCache: (persistentKey, hash) => syncDb.read(persistentKey, hash),
 });
 
 class GeocodingService {
@@ -150,7 +153,7 @@ class GeocodingService {
 }
 ```
 
-Each memoized target gets a `persistentKey` namespace. Lookups check the in-memory cache first, then the persistent storage; promise results are persisted after they resolve.
+Each memoized target gets a `persistentKey` namespace. Lookups check the in-memory cache first, then the persistent storage (synchronously — use a synchronous client or an in-process snapshot for reads); promise results are persisted after they resolve.
 
 ### Cache key functions
 
@@ -192,8 +195,8 @@ Serialization is powered by an embedded fork of [oson](https://github.com/Knorpe
 
 ## Requirements
 
-- **Decorators**: TypeScript 5.0+ (standard decorators, i.e. without `experimentalDecorators`), or Babel with [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/babel-plugin-proposal-decorators) (`version: '2023-05'`).
-- **Runtime**: any modern JavaScript runtime; plain-function usage requires no decorator support at all.
+- **Decorators**: TypeScript 5.0+ (standard decorators, i.e. without `experimentalDecorators`), or Babel with [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/babel-plugin-proposal-decorators) (`version: '2023-11'`).
+- **Runtime**: Node.js 24+ (per the `engines` field); plain-function usage requires no decorator support at all.
 
 ## Contributing
 


### PR DESCRIPTION
## Customer Summary

- The README now reads like a polished OSS project page: a clear one-line pitch, a feature list, installation instructions, a quick-start example, and a task-oriented usage guide covering every public API.
- No code changes; the library behaves exactly the same.

## Technical Summary

- Rewrote `README.md`:
  - Added npm version and license badges alongside the existing Test and semantic-release badges.
  - Added Features, Installation, Quick Start, Usage, API Summary, Requirements, Contributing, and License sections.
  - Documented `memoize`/`memoizeFactory` (with an options table), `memoizeOne`/`memoizeOneWithEmptyHash`/`memoizeOneFactory`, `memoizeWithPersistentCacheFactory`, the cache key functions, and the exported `stringify`/`sha3_512` utilities — previously only the cache-group APIs were documented.
  - Kept the existing `createMemoizeCacheGroup`/`getGlobalMemoizeCacheStore` examples, with added explanations of `WeakRef`-based tracking and `clearMemoizeCaches`.
  - Noted the oson (MIT) and js-sha3 (MIT) derivations in the License section, matching the source headers.
- All examples were written against the current source in `src/` (option names, defaults, and callback signatures verified).

## Why

- The previous README documented only the cache-group APIs and assumed prior familiarity with the package; the core `memoize`/`memoizeOne`/persistent-cache APIs — the main reason to install the library — were undocumented.
- A conventional OSS README structure (features → install → quick start → usage → API summary) lets new users evaluate and adopt the library without reading the source.

## Testing

- `yarn format-code` (oxfmt) to normalize Markdown table formatting.
- Verified documented defaults (`maxCacheSizePerTarget: 10_000`, `cacheDuration: Infinity`, `getCacheKeyOfHash`) and supported serialization types (`Map`, `Set`, `Date`, `RegExp`, `URL`, `Error`, `Uint8Array`, `bigint`, circular references) against `src/memoize.ts`, `src/getCacheKey.ts`, and `src/oson/constructors.ts`.

## Notes (if needed)

- Documentation-only change; no runtime or API impact.
